### PR TITLE
Consistent zookeeper log placement

### DIFF
--- a/bin/cloud-local.sh
+++ b/bin/cloud-local.sh
@@ -74,7 +74,7 @@ function start_first_time {
 
   # start zk
   echo "Starting zoo..."
-  $ZOOKEEPER_HOME/bin/zkServer.sh start
+  (cd $CLOUD_HOME; $ZOOKEEPER_HOME/bin/zkServer.sh start)
 
   # start kafka
   echo "Starting kafka..." 
@@ -126,7 +126,7 @@ function start_cloud {
   
   # start zk
   echo "Starting zoo..."
-  zkServer.sh start
+  (cd $CLOUD_HOME ; zkServer.sh start)
 
   echo "Starting kafka..."
   $KAFKA_HOME/bin/kafka-server-start.sh -daemon $KAFKA_HOME/config/server.properties
@@ -173,7 +173,7 @@ function clear_sw {
   rm -rf "${CLOUD_HOME}/zookeeper-${pkg_zookeeper_ver}"
   rm -rf "${CLOUD_HOME}/kafka_${pkg_kafka_scala_ver}-${pkg_kafka_ver}"
   rm -rf "${CLOUD_HOME}/tmp"
-  if [ -a zookeeper.out ]; then rm zookeeper.out; fi #hahahaha
+  if [ -a "${CLOUD_HOME}/zookeeper.out" ]; then rm "${CLOUD_HOME}/zookeeper.out"; fi #hahahaha
 }
 
 function clear_data {


### PR DESCRIPTION
I have `$CLOUD_HOME/bin` in my path and launch cloud-local from different directories ('cause I can) and i've noticed that I am getting `zookeeper.out` files peppered across my disk.

Changes to launch zookeeper w/ PWD of `$CLOUD_HOME` for consistent log placement.   There are a number of ways to fix this but it this seems like the simplest... 
