### PR TITLE
Use hostname for Accumulo if DNS entry exists

### DIFF
--- a/bin/cloud-local.sh
+++ b/bin/cloud-local.sh
@@ -123,10 +123,11 @@ function start_first_time {
   # create accumulo config
   cp $ACCUMULO_HOME/conf/examples/3GB/standalone/* $ACCUMULO_HOME/conf/
   # if we have a dns entry, change masters and slaves from localhost
-  if ! nslookup ${HOSTNAME}.ccri.com | grep -i "server can't find" ; then
-    sed -i~orig "s/^localhost/${HOSTNAME}.ccri.com/" "${ACCUMULO_HOME}/conf/masters"
-    sed -i~orig "s/^localhost/${HOSTNAME}.ccri.com/" "${ACCUMULO_HOME}/conf/slaves"
-  fi
+  ipaddress="$(ifconfig $(route | grep default | awk '{print $NF}') | grep -o 'inet addr:\S*' | awk -F ':' '{print $NF}')"
+  for CONFIG_FILE in masters slaves gc tracers monitor
+  do
+    sed -i "s/^localhost/${ipaddress}/" "${ACCUMULO_HOME}/conf/${CONFIG_FILE}"
+  done
   # make accumulo bind to all network interfaces (so you can see the monitor from other boxes)
   sed -i~orig "s/\# export ACCUMULO_MONITOR_BIND_ALL=\"true\"/export ACCUMULO_MONITOR_BIND_ALL=\"true\"/" "${ACCUMULO_HOME}/conf/accumulo-env.sh"
  


### PR DESCRIPTION
Adds nslookup check for current hostname to Accumulo configuration
copy step of init. If nslookup succeeds, then replace localhost with
hostname in the Accumulo masters and slaves files to allow for cloud
access by external machines.
