### PR TITLE
Issue #32 : Spark without Hadoop option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ data/*
 /zookeeper*
 /kafka*
 /spark*
+/.idea
+/cloud-local.iml

--- a/bin/cloud-local.sh
+++ b/bin/cloud-local.sh
@@ -50,8 +50,8 @@ function download_packages() {
                    "${mirror}/hadoop/common/hadoop-${pkg_hadoop_ver}/hadoop-${pkg_hadoop_ver}.tar.gz"
                    "${mirror}/zookeeper/zookeeper-${pkg_zookeeper_ver}/zookeeper-${pkg_zookeeper_ver}.tar.gz"
                    "${mirror}/kafka/${pkg_kafka_ver}/kafka_${pkg_kafka_scala_ver}-${pkg_kafka_ver}.tgz"
-                   "${mirror}/spark/spark-${pkg_spark_ver}/spark-${pkg_spark_ver}-bin-hadoop${pkg_spark_hadoop_ver}.tgz")
-  
+                   "${mirror}/spark/spark-${pkg_spark_ver}/spark-${pkg_spark_ver}-bin-without-hadoop.tgz")
+
   for x in "${urls[@]}"; do
       fname=$(basename "$x");
       echo "fetching ${x}";
@@ -65,7 +65,7 @@ function unpackage {
   (cd -P "${CLOUD_HOME}" && tar xvf "${CLOUD_HOME}/pkg/accumulo-${pkg_accumulo_ver}-bin.tar.gz")
   (cd -P "${CLOUD_HOME}" && tar xvf "${CLOUD_HOME}/pkg/hadoop-${pkg_hadoop_ver}.tar.gz")
   (cd -P "${CLOUD_HOME}" && tar xvf "${CLOUD_HOME}/pkg/kafka_${pkg_kafka_scala_ver}-${pkg_kafka_ver}.tgz")
-  (cd -P "${CLOUD_HOME}" && tar xvf "${CLOUD_HOME}/pkg/spark-${pkg_spark_ver}-bin-hadoop${pkg_spark_hadoop_ver}.tgz")
+  (cd -P "${CLOUD_HOME}" && tar xvf "${CLOUD_HOME}/pkg/spark-${pkg_spark_ver}-bin-without-hadoop.tgz")
 }
 
 function configure {
@@ -89,6 +89,8 @@ function configure {
 }
 
 function start_first_time {
+  # This seems redundant to config but this is the first time in normal sequence where it will set properly
+  export SPARK_DIST_CLASSPATH=$(hadoop classpath)
   # check ports
   check_ports
 
@@ -200,7 +202,7 @@ function clear_sw {
   rm -rf "${CLOUD_HOME}/hadoop-${pkg_hadoop_ver}"
   rm -rf "${CLOUD_HOME}/zookeeper-${pkg_zookeeper_ver}"
   rm -rf "${CLOUD_HOME}/kafka_${pkg_kafka_scala_ver}-${pkg_kafka_ver}"
-  rm -rf "${CLOUD_HOME}/spark-${pkg_spark_ver}-bin-hadoop${pkg_spark_hadoop_ver}"
+  rm -rf "${CLOUD_HOME}/spark-${pkg_spark_ver}-bin-without-hadoop"
   rm -rf "${CLOUD_HOME}/tmp"
   if [ -a "${CLOUD_HOME}/zookeeper.out" ]; then rm "${CLOUD_HOME}/zookeeper.out"; fi #hahahaha
 }

--- a/bin/config.sh
+++ b/bin/config.sh
@@ -63,9 +63,12 @@ function set_env_vars {
 
   export ACCUMULO_HOME="$CLOUD_HOME/accumulo-${pkg_accumulo_ver}"
 
-  export SPARK_HOME="$CLOUD_HOME/spark-${pkg_spark_ver}-bin-hadoop${pkg_spark_hadoop_ver}"
+  export SPARK_HOME="$CLOUD_HOME/spark-${pkg_spark_ver}-bin-without-hadoop"
   
   export PATH=$ZOOKEEPER_HOME/bin:$KAFKA_HOME/bin:$ACCUMULO_HOME/bin:$HADOOP_HOME/sbin:$HADOOP_HOME/bin:$SPARK_HOME/bin:$PATH
+
+  # This variable requires Hadoop executable, which will fail during certain runs/steps
+  export SPARK_DIST_CLASSPATH=$(hadoop classpath 2>/dev/null)
 }
 
 if [[ -z "$JAVA_HOME" ]];then

--- a/conf/cloud-local.conf
+++ b/conf/cloud-local.conf
@@ -23,10 +23,11 @@ pkg_zookeeper_ver="3.4.6"
 pkg_kafka_scala_ver="2.11"
 pkg_kafka_ver="0.9.0.0"
 pkg_spark_ver="1.6.1"
-# Note, just the major+minor from Hadoop, not patch level
-pkg_spark_hadoop_ver=${pkg_hadoop_ver:0:3}
 
 
 # accumulo config
 cl_acc_inst_name="local"
 cl_acc_inst_pass="secret"
+
+# Note, just the major+minor from Hadoop, not patch level
+hadoop_base_ver=${pkg_hadoop_ver:0:3}


### PR DESCRIPTION
Smaller download, less disk, still works with Hadoop, Yarn, and Grizzly Bear code so should be good to go if we prefer this option. I believe this D/L requires Hadoop 2.2 and newer.

```
Download Spark without Hadoop and set Spark classpath as needed.
Ignore idea project stuff
```

 Changes to be committed:
    modified:   .gitignore
    modified:   bin/cloud-local.sh
    modified:   bin/config.sh
    modified:   conf/cloud-local.conf
