### PR TITLE
Attempt to use md5 if md5sum fails

### DIFF
--- a/bin/config.sh
+++ b/bin/config.sh
@@ -59,7 +59,7 @@ function set_env_vars {
   export HADOOP_HDFS_HOME="${HADOOP_HOME}"
   export HADOOP_YARN_HOME="${HADOOP_HOME}"
   export HADOOP_PID_DIR="${CLOUD_HOME}/data/hadoop/pid"
-  export HADOOP_IDENT_STRING=$(echo ${CLOUD_HOME} | md5sum | cut -c1-32)
+  export HADOOP_IDENT_STRING=$(echo ${CLOUD_HOME} | (md5sum 2>/dev/null || md5) | cut -c1-32)
 
   export YARN_HOME="${HADOOP_HOME}" 
   export YARN_PID_DIR="${HADOOP_PID_DIR}"


### PR DESCRIPTION
PR includes fallback to `md5` if `md5sum` isn't available (BSD systems)
