### PR TITLE
OSP-1097 make sure cloud cloud-local gets files

### DIFF
--- a/bin/cloud-local.sh
+++ b/bin/cloud-local.sh
@@ -452,7 +452,7 @@ function clear_data {
 }
 
 function show_help {
-  echo "Provide 1 command: (init|start|stop|reconfigure|reyarn|regeoserver|clean|help)"
+  echo "Provide 1 command: (init|start|stop|reconfigure|reyarn|regeoserver|clean|download_only|init_skip_download|help)"
   echo "If the environment variable GEOSERVER_HOME is set then the parameter '-gs' may be used with 'start' to automatically start/stop GeoServer with the cloud."
 }
 
@@ -495,6 +495,10 @@ elif [[ $1 == 'reyarn' ]]; then
 elif [[ $1 == 'regeoserver' ]]; then
   stop_geoserver
   start_geoserver
+elif [[ $1 == 'download_only' ]]; then
+  download_packages
+elif [[ $1 == 'init_skip_download' ]]; then
+  unpackage && configure && start_first_time
 else
   show_help
 fi


### PR DESCRIPTION
In order to deploy cloud-local in a limited network environment, a user could run:

  cloud-local/bin/cloud-local.sh download_only

locally. Transmit a tarball of cloud-local with the downloaded files, and then
continue the initialization on the remote host with:

  cloud-local/bin/cloud-local.sh init_skip_download

PR # - Base_Branch:master