### PR TITLE
Added a config var and logic for a shared pkg folder.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *~
-/pkg/*
+/pkg
 data/*
 *.tar.gz
 /accumulo*

--- a/bin/cloud-local.sh
+++ b/bin/cloud-local.sh
@@ -34,6 +34,18 @@ fi
 . "${bin}"/ports.sh
 
 function download_packages {
+  # Is the pre-download packages variable set?
+  if [[ ! -z ${pkg_pre_download+x} ]]; then
+    # Does that folder actually exist?
+    if [[ -d ${pkg_pre_download} ]] ; then
+      test -d ${CLOUD_HOME}/pkg || rmdir ${CLOUD_HOME}/pkg
+      test -h ${CLOUD_HOME}/pkg && rm ${CLOUD_HOME}/pkg
+      ln -s ${pkg_pre_download} ${CLOUD_HOME}/pkg
+      echo "Skipping downloads... using ${pkg_pre_download}"
+      return 0
+    fi
+  fi
+
   # get stuff
   echo "Downloading packages from internet..."
   test -d ${CLOUD_HOME}/pkg || mkdir ${CLOUD_HOME}/pkg

--- a/conf/cloud-local.conf
+++ b/conf/cloud-local.conf
@@ -10,12 +10,15 @@
 #
 # Set the variable 'pkg_src_mirror' if you want to specify a mirror
 # else it will use https://www.apache.org/dyn/closer.cgi to determine
-# the fastest mirror
+# a mirror. If you have a caching web proxy you may want to set this as well.
 #
 # pkg_src_mirror="http://apache.mirrors.tds.net"
 
 # Specify a maven repository to use
 pkg_src_maven="https://repo1.maven.org/maven2"
+
+# Optionally specifcy a local shared folder of package downloads
+#pkg_pre_download=/net/synds1/volume2/projects2/cloud-local/packages
 
 ################################################################################
 # VERSION MANAGEMENT - Versions of popular software


### PR DESCRIPTION
If you have Internet and want your own pkg folder, that is normal.
If you have Internet and a shared pkg folder, you need to change "pkg" to a symbolic link: wget will download and/or continue.
If you have no-Internet and a shared pkg folder: set pkg to a symbolic link and skip all downloads.