### PR TITLE
Fix zepp url and add Spark ver note

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ derby*
 /.idea
 /cloud-local.iml
 *.iml
+.envrc
+

--- a/bin/cloud-local.sh
+++ b/bin/cloud-local.sh
@@ -449,7 +449,7 @@ function stop_geoserver {
 }
 
 function clear_sw {
-  [[ "$zeppelin_enabled" -eq 1 ]] && rm -rf "${CLOUD_HOME}/zeppelin-${pkg_zeppelin_ver}"
+  [[ "$zeppelin_enabled" -eq 1 ]] && rm -rf "${CLOUD_HOME}/zeppelin-${pkg_zeppelin_ver}-bin-all"
   [[ "$acc_enabled" -eq 1 ]] && rm -rf "${CLOUD_HOME}/accumulo-${pkg_accumulo_ver}"
   [[ "$hbase_enabled" -eq 1 ]] && rm -rf "${CLOUD_HOME}/hbase-${pkg_hbase_ver}"
   [[ -d "${CLOUD_HOME}/geomesa-accumulo_${pkg_geomesa_scala_ver}-${pkg_geomesa_ver}"  ]] && rm -rf "${CLOUD_HOME}/geomesa-accumulo_${pkg_geomesa_scala_ver}-${pkg_geomesa_ver}"

--- a/bin/cloud-local.sh
+++ b/bin/cloud-local.sh
@@ -101,7 +101,7 @@ function download_packages {
   fi
 
   if [[ "$zeppelin_enabled" -eq 1 ]]; then
-    urls=("${urls[@]}" "${apache_archive_url}zeppelin/zeppelin-${pkg_zeppelin_ver}/zeppelin-${pkg_zeppelin_ver}-bin-all.tgz")
+    urls=("${urls[@]}" "${apache_archive_url}/zeppelin/zeppelin-${pkg_zeppelin_ver}/zeppelin-${pkg_zeppelin_ver}-bin-all.tgz")
   fi
 
   for x in "${urls[@]}"; do

--- a/conf/cloud-local.conf
+++ b/conf/cloud-local.conf
@@ -48,6 +48,7 @@ pkg_geomesa_scala_ver="2.11"
 pkg_scala_ver="2.11.7"
 
 # Apache Zeppelin, yet another analyst notebook that knows about Spark
+# You must change Spark to a compatible version (2.1.x)
 pkg_zeppelin_ver="0.7.2"
 
 ################################################################################
@@ -108,5 +109,6 @@ if [[ -z "${pkg_scala_ver}" && "${scala_enabled}" -eq "1" ]]; then
 fi
 
 # Enable/Disable Zepplin
+# You must change Spark to a compatible version (2.1.x)
 zeppelin_enabled=0
 

--- a/conf/cloud-local.conf
+++ b/conf/cloud-local.conf
@@ -37,7 +37,7 @@ pkg_zookeeper_ver="3.4.10"
 pkg_kafka_scala_ver="2.11"
 pkg_kafka_ver="0.9.0.1"
 
-pkg_spark_ver="2.2.0"
+pkg_spark_ver="2.2.1"
 # Note pkg_hadoop_ver above
 #  - don't auto-derive this as spark & hadoop major releases aren't lock-step
 #  - use "without-hadoop" to use version without hadoop deps
@@ -48,8 +48,8 @@ pkg_geomesa_scala_ver="2.11"
 pkg_scala_ver="2.11.7"
 
 # Apache Zeppelin, yet another analyst notebook that knows about Spark
-# You must change Spark to a compatible version (2.1.x)
-pkg_zeppelin_ver="0.7.2"
+# You must change Spark to a compatible version (e.g. Zep 0.7.2 with Spark 2.1 and Zep 0.7.3 with Spark 2.2)
+pkg_zeppelin_ver="0.7.3"
 
 ################################################################################
 # ACCUMULO CONFIGURATION
@@ -109,6 +109,5 @@ if [[ -z "${pkg_scala_ver}" && "${scala_enabled}" -eq "1" ]]; then
 fi
 
 # Enable/Disable Zepplin
-# You must change Spark to a compatible version (2.1.x)
+# Ensure that your Spark+Zeppelin versions are compatible
 zeppelin_enabled=0
-


### PR DESCRIPTION
Discovered URL problem with #64  Also added comment notes in config regarding compatible Spark version. I didn't create a Zeppelin notebook but the Zeppelin service downloaded and started and also Spark 2.1 downloaded. (After setting the config to enable zeppelin and change Spark version.)